### PR TITLE
Added custom tlscert_naming example JSON template

### DIFF
--- a/infrastructure/iam/tlscert_naming.json.j2
+++ b/infrastructure/iam/tlscert_naming.json.j2
@@ -1,0 +1,14 @@
+{
+  "dev": {
+    "wildcard.example.com": "arn:aws:iam::{account}:server-certificate/{name}-2017-07-15"
+  },
+  "stage": {
+    "wildcard.example.com": "arn:aws:iam::{account}:server-certificate/{name}",
+    "service.example.com": "arn:aws:iam::{account}:server-certificate/{name}-service-2017-07-15",
+    "custom-name": "arn:aws:iam::{account}:server-certificate/{name}-custom-etc"
+  },
+  "prod": {
+    "wildcard.example.com": "arn:aws:iam::{account}:server-certificate/{name}",
+    "service.example.com": "arn:aws:iam::{account}:server-certificate/{name}-custom-etc"
+  }
+}

--- a/infrastructure/iam/tlscert_naming.json.j2
+++ b/infrastructure/iam/tlscert_naming.json.j2
@@ -1,14 +1,14 @@
 {
   "dev": {
-    "wildcard.example.com": "arn:aws:iam::{account}:server-certificate/{name}-2017-07-15"
+    "wildcard.example.com": "arn:aws:iam::{{ account }}:server-certificate/{{ name }}-2017-07-15"
   },
   "stage": {
-    "wildcard.example.com": "arn:aws:iam::{account}:server-certificate/{name}",
-    "service.example.com": "arn:aws:iam::{account}:server-certificate/{name}-service-2017-07-15",
-    "custom-name": "arn:aws:iam::{account}:server-certificate/{name}-custom-etc"
+    "wildcard.example.com": "arn:aws:iam::{{ account }}:server-certificate/{{ name }}",
+    "service.example.com": "arn:aws:iam::{{ account }}:server-certificate/{{ name }}-service-2017-07-15",
+    "custom-name": "arn:aws:iam::{{ account }}:server-certificate/{{ name }}-custom-etc"
   },
   "prod": {
-    "wildcard.example.com": "arn:aws:iam::{account}:server-certificate/{name}",
-    "service.example.com": "arn:aws:iam::{account}:server-certificate/{name}-custom-etc"
+    "wildcard.example.com": "arn:aws:iam::{{ account }}:server-certificate/{{ name }}",
+    "service.example.com": "arn:aws:iam::{{ account }}:server-certificate/{{ name }}-custom-etc"
   }
 }


### PR DESCRIPTION
- This will allow developers to specify a friendly cert name, foremast will compile the proper cert ARN to use in AWS. Useful when trying to rotate ssl certificates.
