### PR TITLE
feat: Added missing Lambda trust policy and added missing features

### DIFF
--- a/infrastructure/app_data.json.j2
+++ b/infrastructure/app_data.json.j2
@@ -2,22 +2,55 @@
 "job": [
     {%for account in appinfo.accounts %}
     {
-        "type":"createApplication",
+        "type": "createApplication",
         "account":"{{ account.name }}",
         "application":{
-            "cloudProviders":"aws",
+            "cloudProviders": "aws",
             "name": "{{ appinfo.app }}",
             "email": "{{ appinfo.email }}",
             "repoType": "github",
             "repoProjectKey": "{{ appinfo.project }}",
             "repoSlug": "{{ appinfo.repo }}",
-            "platformHealthOnlyShowOverride": true
+            "platformHealthOnlyShowOverride": true,
+            "permissions": {
+                "READ": {{ pipeline_config.permissions.read_roles | tojson }},
+                "WRITE": {{ pipeline_config.permissions.write_roles | tojson }}
+            },
+            "chaosMonkey": {
+                "enabled": {{ pipeline_config.chaos_monkey.enabled | tojson }},
+                "meanTimeBetweenKillsInWorkDays": {{ pipeline_config.chaos_monkey.mean_time }},
+                "minTimeBetweenKillsInWorkDays": {{ pipeline_config.chaos_monkey.minimum_time }},
+                "grouping": "cluster",
+                "regionsAreIndependent": true,
+                "exceptions": [{% for exception in pipeline_config.chaos_monkey.exceptions %}
+                    {"account": {{ exception | tojson }}, "region": "*", "stack": "*" }
+                    {% if not loop.last %},{% endif %}
+                    {% endfor %}
+                ]
+            },
+            "instanceLinks": [{
+                "title": "Links",
+                "links": [{% for key, value in pipeline_config.instance_links.items() %}
+                    {"title": "{{ key }}", "path": "{{ value }}" }{% if not loop.last %},{% endif %}
+                    {% endfor %}
+                ]
+            }],
+            "trafficGuards": [{% for account_name in pipeline_config.traffic_guards.accounts %}
+                {
+                    "account": {{ account_name | tojson }},
+                    "detail": "*",
+                    "location": "*",
+                    "region": "*",
+                    "stack": "*"
+                }
+                {% if not loop.last %},{% endif %}
+                {% endfor %}
+            ]
         },
-        "user":"foremast"
+        "user": "foremast"
     }{% if not loop.last %},{% endif %}
     {% endfor %}
   ],
 "application": "{{ appinfo.app }}",
 "description": "Created application {{ appinfo.app }}"
 }
-

--- a/infrastructure/autoscaling_policy.json.j2
+++ b/infrastructure/autoscaling_policy.json.j2
@@ -35,7 +35,11 @@
             "stepAdjustments":[
                {
                   "scalingAdjustment":{{ scalingAdjustment }},
+                  {% if operation == "decrease" %}
+                  "metricIntervalUpperBound":0
+                  {% else %}
                   "metricIntervalLowerBound":0
+                  {% endif %}
                }
             ]
          },

--- a/infrastructure/iam/tlscert_naming.json.j2
+++ b/infrastructure/iam/tlscert_naming.json.j2
@@ -1,28 +1,28 @@
 {
+	"acm": {
+		"us-east-1": {
+			"stage": {
+				"wildcard.stage.example.com": "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555",
+				"wildcard.backend.stage.example.com": "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555",
+				"wildcard.frontend.stage.example.com": "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+			},
+			"prod": {
+				"wildcard.prod.example.com": "arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555",
+				"wildcard.backend.stage.example.com": "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+			}
+		},
+		"us-west-2": {
+			"stage": {
+				"wildcard.stage.example.com": "arn:aws:acm:us-west-2:123456789012:certificate/11111111-0000-2222-3333-555555555555"
+			}
+		}
+	},
 	"iam": {
-		"dev": {
+		"stage": {
 			"wildcard.example.com": "arn:aws:iam::123456789012:server-certificate/wildcard.example.com-2020-07-15"
 		},
 		"prod": {
 			"wildcard.example.com": "arn:aws:iam::210987654321:server-certificate/wildcard.example.com-2020-07-15"
-		}
-	},
-	"acm": {
-		"us-east-1": {
-			"dev": {
-				"wildcard.dev.example.com": "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
-			},
-			"prod": {
-				"wildcard.prod.example.com": "arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555"
-			}
-		},
-		"us-west-2": {
-			"dev": {
-				"wildcard.dev.example.com": "arn:aws:acm:us-west-2:123456789012:certificate/11111111-0000-2222-3333-555555555555"
-			},
-			"prod": {
-				"wildcard.prod.example.com": "arn:aws:acm:us-west-2:210987654321:certificate/11111111-0000-2222-3333-555555555555"
-			}
 		}
 	}
 }

--- a/infrastructure/iam/trust/lambda_role.json.j2
+++ b/infrastructure/iam/trust/lambda_role.json.j2
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": [
+            "edgelambda.amazonaws.com",
+            "lambda.amazonaws.com"
+        ]
+      }
+    }
+  ]
+}

--- a/infrastructure/user_data.sh.j2
+++ b/infrastructure/user_data.sh.j2
@@ -1,6 +1,11 @@
 #!/bin/bash
+
+# Define more userdata if needed to expose delivery variables at compute level
+#
+# This is useful to allow the applications to transform to their appropriate region
+# based on Environment Variables.
 export CLOUD_ENVIRONMENT={{ env }}
 export CLOUD_APP={{ app_name }}
-export EC2_REGION={{ region }}
+export CLOUD_REGION={{ region }}
 export CLOUD_CANARY={{ canary }}
 printenv | grep 'CLOUD\|EC2' | awk '$0="export "$0' >> /etc/cloud_env


### PR DESCRIPTION
- Chaos Monkey, Instance Links, and Traffic Guards missing from examples (but defined in core)
  this should enable new users to have an up to date config.
- Re-Ordered ACM to top of tls naming to show preference for v2.
- Added Comments to UserData section to show potential further usages